### PR TITLE
Hachoir logs

### DIFF
--- a/characterize.py
+++ b/characterize.py
@@ -105,7 +105,7 @@ def get_type_val(data: str, src_name: str) -> Tuple[str, str]:
 #########################################################
 class Characterize(ServiceBase):
     def hachoir_logger_callback(self, level, prefix, _text, ctxt):
-        log = f"{prefix}: {_text}"
+        log = f"hachoir: {_text}"
         if Log.LOG_INFO == level:
             self.log.info(log)
         elif Log.LOG_WARN == level:

--- a/characterize.py
+++ b/characterize.py
@@ -6,7 +6,7 @@ import subprocess
 from typing import Dict, List, Tuple, Union
 
 import hachoir.core.config as hachoir_config
-from hachoir.core.log import log as hachoir_logger, Log
+from hachoir.core.log import log as hachoir_logger, Log, Logger
 from hachoir.metadata import extractMetadata
 from hachoir.parser.guess import createParser
 
@@ -104,8 +104,10 @@ def get_type_val(data: str, src_name: str) -> Tuple[str, str]:
 #                  Scan Execution Class                 #
 #########################################################
 class Characterize(ServiceBase):
-    def hachoir_logger_callback(self, level, prefix, _text, ctxt):
-        log = f"hachoir: {_text}"
+    def hachoir_logger_callback(self, level: int, prefix: str, _text: str,
+                                ctxt: Optional[Logger]) -> None:
+        # Show where in hachoir the log comes from using ctxt if it exists
+        log = f"hachoir [{ctxt._logger()}]: {_text}" if ctxt else f"hachoir: {_text}"
         if Log.LOG_INFO == level:
             self.log.info(log)
         elif Log.LOG_WARN == level:

--- a/characterize.py
+++ b/characterize.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import json
 import re
 import subprocess
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import hachoir.core.config as hachoir_config
 from hachoir.core.log import log as hachoir_logger, Log, Logger


### PR DESCRIPTION
Most of our characterize logs are from hachoir but don't indicate where in hachoir they come from.
Using the ctxt field to indicate which class logged the error, and prefixing hachoir logs with "hachoir" to separate them from assemblyline logs.